### PR TITLE
Adds SHA1 hash to API-SECRET header

### DIFF
--- a/TidepoolToNightScoutSync.BL/Services/Nightscout/NightscoutClient.cs
+++ b/TidepoolToNightScoutSync.BL/Services/Nightscout/NightscoutClient.cs
@@ -48,6 +48,7 @@ namespace TidepoolToNightScoutSync.BL.Services.Nightscout
         public async Task<IReadOnlyList<Treatment>> AddTreatmentsAsync(IEnumerable<Treatment> treatments) =>
             await _client
                 .PostAsync("api/v1/treatments", treatments)
+                .WithHeader("api-secret", SHA1(_options.ApiKey))
                 .AsArray<Treatment>();
 
         /// <summary>


### PR DESCRIPTION
Fixes 401 replies from Nightscout's POST api/v1/treatments.json endpoint.

See: https://github.com/nightscout/cgm-remote-monitor/issues/5199#issuecomment-553807385

> To authenticate with the API your app neds to send the same
> `API_SECRET` password as a `SHA1` Hash in the HTTP Headers as
> `API-SECRET`

Adds header to POST /api/v1/treatments.json.